### PR TITLE
Association Delegation

### DIFF
--- a/lib/active_record/acts/as_relation.rb
+++ b/lib/active_record/acts/as_relation.rb
@@ -39,11 +39,12 @@ module ActiveRecord
               base.has_one :#{name}, :as => :#{name}, :autosave => true, :validate => false
               base.validate :#{name}_must_be_valid
               base.alias_method_chain :#{name}, :autobuild
-              
+
               base.extend ActiveRecord::Acts::AsRelation::AccessMethods
               all_attributes = #{name.camelcase.constantize}.content_columns.map(&:name)
               ignored_attributes = ["created_at", "updated_at", "#{name}_type"]
-              attributes_to_delegate = all_attributes - ignored_attributes
+              associations = #{name.camelcase.constantize}.reflect_on_all_associations(:belongs_to).map! { |assoc| assoc.name }
+              attributes_to_delegate = all_attributes - ignored_attributes + associations
               base.define_acts_as_accessors(attributes_to_delegate, "#{name}")
             end
             

--- a/test/acts_as_relation_test.rb
+++ b/test/acts_as_relation_test.rb
@@ -65,6 +65,15 @@ class ActsAsRelationTest < ActiveSupport::TestCase
     assert(pencil.respond_to? :color_was)
   end
 
+  test "association reflections" do
+    store = Store.new
+    pen = Pen.new
+    pen.store = store
+
+    assert_equal store, pen.product.store
+    assert_equal store, pen.store
+  end
+
 end
 
 #ActiveRecord::Base.connection.tables.each do |table|

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -8,6 +8,11 @@ ActiveRecord::Base.establish_connection(
 )
 
 ActiveRecord::Schema.define(:version => 1) do
+
+  create_table :stores do |t|
+    t.string :store_name
+  end
+
   create_table :products do |t|
     t.string  :name
     t.float   :price
@@ -22,7 +27,12 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :pencils
 end
 
+class Store < ActiveRecord::Base
+  has_many :products
+end
+
 class Product < ActiveRecord::Base
+  belongs_to :store
   validates_presence_of :name, :price
 end
 


### PR DESCRIPTION
Currently associations on parent models such as belongs_to are not being delegated back to the parent model.

This update checks for any belongs_to associations defined on the parent model and creates delegate methods for them.  Only the belongs_to association has been updated since I could not think of an applicable case where has_many or has_one may wish to be delegated but the update could be easily modified to include them as well if desired.
