### PR TITLE
Fixing test schema so that tests involving pencil are passing again

### DIFF
--- a/test/schema.rb
+++ b/test/schema.rb
@@ -17,6 +17,8 @@ ActiveRecord::Schema.define(:version => 1) do
 
   create_table :pens do |t|
     t.string  :color
+    t.integer :pen_id
+    t.string :pen_type
   end
 
   create_table :pencils


### PR DESCRIPTION
I've updated the test schema so that the Pen model has pen_type and pen_id columns since they are required for Pencil to act_as Pen allowing tests to pass once again.
