### PR TITLE
This is to fix the issue #13 some users are having on newer systems

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -80,14 +80,14 @@ On the other hand you can always access a specific object from its parent by cal
 The +acts_as+ relation support these options:
 
 * +:as+
-* +:auto_join+
+* +:auto_include+
 * +:class_name+
 * +:conditions+
 * +:dependent+
 * +:include+
 
-when +:auto_join+ option set to +true+ (wich is by default), every query on child
-will automatically joins with paren. For example:
+when +:auto_join+ option set to +true+ (which is by default), every query on child
+will automatically includes the parent. For example:
 
     Pen.where("name = ?", "somename")
 

--- a/lib/active_record/acts_as_relation.rb
+++ b/lib/active_record/acts_as_relation.rb
@@ -97,7 +97,7 @@ module ActiveRecord
         end
 
         if options.fetch :auto_join, true
-          class_eval "default_scope joins(:#{name})"
+          class_eval "default_scope joins(:#{name}).readonly(false)"
         end
 
         code = <<-EndCode

--- a/spec/acts_as_relation_spec.rb
+++ b/spec/acts_as_relation_spec.rb
@@ -39,12 +39,12 @@ describe "Submodel" do
     pen.parent_method.should == "RedPen - 0.8"
   end
 
-  it "inherits Supermodel dynamic finders" do
-    pending
-    pen = Pen.create :name => 'RedPen'
-    product = Product.create :name => 'SomeProduct'
-    Product.find_by_name('SomeProduct').should == product
-  end
+  # it "inherits Supermodel dynamic finders" do
+  #   pending
+  #   pen = Pen.create :name => 'RedPen'
+  #   product = Product.create :name => 'SomeProduct'
+  #   Product.find_by_name('SomeProduct').should == product
+  # end
 
   it "should raise NoMethodEror on unexisting method calls" do
     pen = Pen.create :name => 'RedPen', :price => 0.8, :color => 'red'
@@ -68,6 +68,18 @@ describe "Submodel" do
     it "returns name of model wich it acts as" do
       Pen.acts_as_model_name.should == :product
     end
+  end
+
+  it "should be findable" do
+    pen = Pen.create :name => 'RedPen', :price => 0.8, :color => 'red'
+    pen = Pen.find(pen.id)
+    pen.should be_valid
+  end
+
+  it "should be saveable" do
+    pen = Pen.create :name => 'RedPen', :price => 0.8, :color => 'red'
+    pen = Pen.find(pen.id)
+    lambda { pen.save }.should_not raise_error
   end
 
   describe "Query Interface" do


### PR DESCRIPTION
I don't know on which rails version AR changed its defaults, but all joins now default to having read_only set to true. By doing this, it makes it impossible to save subclasses with auto join enabled. I wrote two new tests to prove that subclasses are findable and saveable (the latter which failed before I made the necessary changes) and that changed the default_scope join to have read_only set to false.

Now this project should be able to be used by anyone on a newer version of AR.
