### PR TITLE
Only forward attr_accessible if needed

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -84,9 +84,7 @@ The +acts_as+ relation support these options:
 * +:as+
 * +:auto_join+
 * +:class_name+
-* +:conditions+
 * +:dependent+
-* +:include+
 
 when +:auto_join+ option set to +true+ (which is by default), every query on child
 will automatically joins the parent table. For example:
@@ -98,3 +96,9 @@ will result in the following SQL:
     SELECT "pens".* FROM "pens" INNER JOIN "products" ON "products"."as_product_id" = "pens"."id" AND "products"."as_product_type" = 'Pen' WHERE (name = 'somename')
 
 All other options are same as +has_one+ options.
+
+Note that support for +:conditions+ and +:include+ has been removed. In their place, you can use
++where()+ and +includes()+:
+
+    acts_as :product, -> { where(color: "yellow") }
+

--- a/lib/active_record/acts_as_relation.rb
+++ b/lib/active_record/acts_as_relation.rb
@@ -113,10 +113,10 @@ module ActiveRecord
         end
 
         if options.fetch :auto_join, true
-          class_eval "default_scope joins(:#{name})"
+          class_eval "default_scope -> { joins(:#{name}) }"
         end
 
-        class_eval "default_scope readonly(false)"
+        class_eval "default_scope -> { readonly(false) }"
 
         code = <<-EndCode
           def acts_as_other_model?

--- a/lib/active_record/acts_as_relation.rb
+++ b/lib/active_record/acts_as_relation.rb
@@ -49,6 +49,11 @@ module ActiveRecord
             :conditions => options[:conditions]
           }
 
+          attr_accessible = if Rails.version < "4" or defined?(::ProtectedAttributes)
+            "base.attr_accessible.update(#{class_name}.attr_accessible)"
+          else
+            ""
+          end
           code = <<-EndCode
             def self.included(base)
               base.has_one :#{name}, #{has_one_options}
@@ -62,7 +67,7 @@ module ActiveRecord
               attributes_to_delegate = attributes + associations - ignored
               base.send :define_acts_as_accessors, attributes_to_delegate, "#{name}"
 
-              base.attr_accessible.update(#{class_name}.attr_accessible)
+              #{attr_accessible}
             end
 
             def #{name}_with_autobuild


### PR DESCRIPTION
`attr_accessible` has been deprecated in Rails 4 in favour of strong parameters, and extracted to a gem. Attempting to use it without this gem results in the following error:

`RuntimeError: `attr_accessible` is extracted out of Rails into a gem. Please use new recommended protection model for params(strong_parameters) or add `protected_attributes` to your Gemfile to use old one.`

This change fixes that by only calling attr_accessible in Rails versions < 4 or when the `protected_attributes` gem is loaded.
