### PR TITLE
Updated README code example to conform to accompanying explanation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,6 +53,10 @@ you must pass name to +acts_as+ in +:as+ option:
   class Pen < ActiveRecord::Base
     acts_as :product, :as => :producible
   end
+  
+  class Book < ActiveRecord::Base
+    acts_as :product, :as => :producible
+  end
 
 Now +Pen+ and +Book+ *act* *as* +Product+. This means that they inherit +Product+
 _attributes_, _associations_, _validations_ and _methods_.


### PR DESCRIPTION
A code example lacked the Book model declaration which was subsequently mentioned in the example's accompanying explanation. While a minor error, it could be confusing to an acts_as_relation newcomer.
