### PR TITLE
Automatically generate an index for the generated columns for inherited objects

### DIFF
--- a/lib/active_record/acts_as_relation_superclass_migration.rb
+++ b/lib/active_record/acts_as_relation_superclass_migration.rb
@@ -17,6 +17,8 @@ module ActiveRecord
 
           td.integer "#{association_name}_id"
           td.string  "#{association_name}_type"
+          td.index ["#{association_name}_id", "#{association_name}_type"],
+                   name: "#{association_name}_index"
         end
 
         yield td if block_given?


### PR DESCRIPTION
Tested with Rails 4.1 and MySQL, and did an EXPLAIN.
