### PR TITLE
When generating a superclass object, ensure backlinks are made

### DIFF
--- a/lib/active_record/acts_as_relation/acts_as_modules.rb
+++ b/lib/active_record/acts_as_relation/acts_as_modules.rb
@@ -38,9 +38,11 @@ module ActiveRecord
             const_set('ClassMethods', class_methods)
 
             define_method "#{acts_as.name}_with_autobuild" do
-              send("#{acts_as.name}_without_autobuild") || send("build_#{acts_as.name}")
-              result = send("#{name}_without_autobuild") || send("build_#{name}")
-              result.send("#{association_name}=", self) unless result.send(association_name)
+              result = send("#{acts_as.name}_without_autobuild")
+              unless result
+                result = send("build_#{acts_as.name}")
+                result.send("#{acts_as.association_name}=", self)
+              end
               result
             end
 

--- a/lib/active_record/acts_as_relation/acts_as_modules.rb
+++ b/lib/active_record/acts_as_relation/acts_as_modules.rb
@@ -40,7 +40,7 @@ module ActiveRecord
             define_method "#{acts_as.name}_with_autobuild" do
               send("#{acts_as.name}_without_autobuild") || send("build_#{acts_as.name}")
               result = send("#{name}_without_autobuild") || send("build_#{name}")
-              result.send("#{association_name}=", self)
+              result.send("#{association_name}=", self) unless result.send(association_name)
               result
             end
 

--- a/lib/active_record/acts_as_relation/acts_as_modules.rb
+++ b/lib/active_record/acts_as_relation/acts_as_modules.rb
@@ -39,6 +39,9 @@ module ActiveRecord
 
             define_method "#{acts_as.name}_with_autobuild" do
               send("#{acts_as.name}_without_autobuild") || send("build_#{acts_as.name}")
+              result = send("#{name}_without_autobuild") || send("build_#{name}")
+              result.send("#{association_name}=", self)
+              result
             end
 
             define_method :method_missing do |method, *arg, &block|


### PR DESCRIPTION
This is a case which can happen when there is a 1:many relationship between some other model and the superclass. You will have to use the #superclass message to obtain the superclass instance. However, there is no reverse relationship. So when the relationship from the superclass object is persisted, the derived object is not, because the relationship is one-way.

Example (using sample app, derived from my own code base)

``` ruby
store = Store.new
pen = Pen.new
store.products << pen.producible
store.save
```

The Producible bit of the Pen will be saved, but the Pen itself will not.
