### PR TITLE
[Behaviour Change] Implement proper inheritance behaviour

### DIFF
--- a/lib/active_record/acts_as_relation.rb
+++ b/lib/active_record/acts_as_relation.rb
@@ -27,18 +27,16 @@ module ActiveRecord
       end
       alias :is_a :acts_as
 
-      def acts_as_superclass options={}
-        association_name = options[:as] || acts_as_association_name
+      def acts_as_superclass(options={})
+        association_name = (options[:as] || acts_as_association_name).to_sym
 
-        code = <<-EndCode
-          belongs_to :#{association_name}, :polymorphic => true
+        class_eval do
+          belongs_to association_name, polymorphic: true
 
-          def specific
-            self.#{association_name}
-          end
-          alias :specific_class :specific
+          alias_method :specific, association_name
+          alias_method :specific_class, :specific
 
-          def method_missing method, *arg, &block
+          def method_missing(method, *arg, &block)
             if specific and specific.respond_to?(method)
               specific.send(method, *arg, &block)
             else
@@ -46,17 +44,16 @@ module ActiveRecord
             end
           end
 
-          def is_a? klass
+          def is_a?(klass)
             (specific and specific.class == klass) ? true : super
           end
           alias_method :instance_of?, :is_a?
           alias_method :kind_of?, :is_a?
-        EndCode
-        class_eval code, __FILE__, __LINE__
+        end
       end
       alias :is_a_superclass :acts_as_superclass
 
-      def acts_as_association_name model_name=nil
+      def acts_as_association_name(model_name=nil)
         model_name ||= self.name
         "as_#{model_name.to_s.demodulize.singularize.underscore}"
       end

--- a/lib/active_record/acts_as_relation/access_methods.rb
+++ b/lib/active_record/acts_as_relation/access_methods.rb
@@ -2,26 +2,39 @@ module ActiveRecord
   module ActsAsRelation
     module AccessMethods
       protected
-      def define_acts_as_accessor(attrib, model_name)
-        class_eval do
-          define_method attrib do
-            send(model_name).send(attrib)
-          end
-
-          define_method "#{attrib}=" do |value|
-            send(model_name).send("#{attrib}=", value)
-          end
-
-          define_method "#{attrib}?" do
-            send(model_name).send("#{attrib}?")
-          end
-        end
-      end
-
       def define_acts_as_accessors(attribs, model_name)
-        attribs.each do |attrib|
-          define_acts_as_accessor(attrib, model_name)
-        end
+        # The weird order of the if-else branches is so that we query ourselves
+        # before we query our superclass.
+        class_eval <<-EndCode, __FILE__, __LINE__ + 1
+          def method_missing(method, *args, &proc)
+            if #{model_name}.respond_to?(method)
+              self.class_eval do
+                delegate method, to: :#{model_name}
+              end
+              #{model_name}.send(method, *args, &proc)
+            else
+              super
+            end
+          end
+
+          def read_attribute(attr_name, *args, &proc)
+            if attribute_method?(attr_name.to_s)
+              super(attr_name, *args)
+            else
+              #{model_name}.read_attribute(attr_name, *args, &proc)
+            end
+          end
+
+          private
+
+          def write_attribute(attr_name, *args, &proc)
+            if attribute_method?(attr_name.to_s)
+              super(attr_name, *args)
+            else
+              #{model_name}.send(:write_attribute, attr_name, *args, &proc)
+            end
+          end
+        EndCode
       end
     end
   end

--- a/lib/active_record/acts_as_relation/access_methods.rb
+++ b/lib/active_record/acts_as_relation/access_methods.rb
@@ -34,6 +34,14 @@ module ActiveRecord
             end
           end
 
+          def save(*args)
+            super(*args) && #{model_name}.save(*args)
+          end
+
+          def save!(*args)
+            super(*args) && #{model_name}.save!(*args)
+          end
+
           private
 
           def write_attribute(attr_name, *args, &proc)

--- a/lib/active_record/acts_as_relation/access_methods.rb
+++ b/lib/active_record/acts_as_relation/access_methods.rb
@@ -6,17 +6,6 @@ module ActiveRecord
         # The weird order of the if-else branches is so that we query ourselves
         # before we query our superclass.
         class_eval <<-EndCode, __FILE__, __LINE__ + 1
-          def method_missing(method, *args, &proc)
-            if #{model_name}.respond_to?(method)
-              self.class_eval do
-                delegate method, to: :#{model_name}
-              end
-              #{model_name}.send(method, *args, &proc)
-            else
-              super
-            end
-          end
-
           def read_attribute(attr_name, *args, &proc)
             if attribute_method?(attr_name.to_s)
               super(attr_name, *args)

--- a/lib/active_record/acts_as_relation/access_methods.rb
+++ b/lib/active_record/acts_as_relation/access_methods.rb
@@ -25,6 +25,15 @@ module ActiveRecord
             end
           end
 
+          def touch(name = nil, *args, &proc)
+            if attribute_method?(name.to_s)
+              super(name, *args, &proc)
+            else
+              super(nil, *args, &proc)
+              #{model_name}.touch(name, *args, &proc)
+            end
+          end
+
           private
 
           def write_attribute(attr_name, *args, &proc)

--- a/lib/active_record/acts_as_relation/acts_as_modules.rb
+++ b/lib/active_record/acts_as_relation/acts_as_modules.rb
@@ -15,7 +15,7 @@ module ActiveRecord
           has_one_options = {
             as:         acts_as.association_name,
             class_name: acts_as.class_name,
-	          inverse_of: acts_as.association_name.to_sym,
+            inverse_of: acts_as.association_name.to_sym,
             autosave:   true,
             validate:   false,
             dependent:  acts_as.options.fetch(:dependent, :destroy),

--- a/lib/active_record/acts_as_relation/acts_as_modules.rb
+++ b/lib/active_record/acts_as_relation/acts_as_modules.rb
@@ -15,6 +15,7 @@ module ActiveRecord
           has_one_options = {
             as:         acts_as.association_name,
             class_name: acts_as.class_name,
+	          inverse_of: acts_as.association_name.to_sym,
             autosave:   true,
             validate:   false,
             dependent:  acts_as.options.fetch(:dependent, :destroy),

--- a/lib/active_record/acts_as_relation/acts_as_modules.rb
+++ b/lib/active_record/acts_as_relation/acts_as_modules.rb
@@ -43,9 +43,12 @@ module ActiveRecord
             end
 
             define_method :method_missing do |method, *arg, &block|
-              if (method.to_s == 'id' || method.to_s == name) || !send(acts_as.name).respond_to?(method)
+              if (method.to_s == 'id' || method.to_s == acts_as.name) || !send(acts_as.name).respond_to?(method)
                 super(method, *arg, &block)
               else
+                self.class_eval do
+                  delegate method, to: acts_as.name
+                end
                 send(acts_as.name).send(method, *arg, &block)
               end
             end


### PR DESCRIPTION
The old gem behaviour is to always delegate properties that are defined in the superclass, even if the derived class implements them. This is risky when identically named columns and properties are defined in both super and derived classes.
I've redefined the behaviour such that a dynamically (lazy) resolution of procedures is performed instead, always querying the derived class to see if such a method is defined, before forwarding to the superclass. This should restore proper OOP behaviour.
As a side effect, this works with the Paranoia gem, where the deleted_at column need only be defined in the superclass.
