### PR TITLE
Fix support for class_names where a module name is included.

### DIFF
--- a/lib/active_record/acts_as_relation/acts_as.rb
+++ b/lib/active_record/acts_as_relation/acts_as.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         @class_name       = @options[:class_name] || @name.to_s.camelcase
         @model            = @class_name.constantize
         @association_name = @options[:as] || @model.acts_as_association_name
-        @module_name      = "ActsAs#{class_name}"
+        @module_name      = "ActsAs#{name.to_s.camelcase}"
         @module = ActiveRecord::ActsAsRelation::ActsAsModules.module_for(self)
       end
 


### PR DESCRIPTION
Restore the old Gem behaviour of using the table name to generate the ActsAsModule name. This is because the class name might containing modules and so ActsAsModuleName::ClassName does not work (ActsAsTableName would.)
