### PR TITLE
Fix reading of read_attribute

### DIFF
--- a/lib/active_record/acts_as_relation/access_methods.rb
+++ b/lib/active_record/acts_as_relation/access_methods.rb
@@ -6,7 +6,7 @@ module ActiveRecord
         # before we query our superclass.
         class_eval <<-EndCode, __FILE__, __LINE__ + 1
           def read_attribute(attr_name, *args, &proc)
-            if attribute_method?(attr_name)
+            if attribute_method?(attr_name.to_s)
               super(attr_name, *args)
             else
               #{model_name}.read_attribute(attr_name, *args, &proc)


### PR DESCRIPTION
Since read_attribute is given symbols, and internally ActiveRecord checks using strings (notably, id == attr_name)
